### PR TITLE
Grid.js static grid

### DIFF
--- a/src/maps/Grid.js
+++ b/src/maps/Grid.js
@@ -1,0 +1,48 @@
+/**
+ * @author Raffaello Bonghi - raffaello.bonghi@officinerobotiche.it
+ */
+
+/**
+ * A Grid object draw in map.
+ *
+ * @constructor
+ * @param options - object with following keys:
+ *  * size (optional) - the size of the grid
+ *  * cellSize (optional) - the cell size of map
+ *  * lineWidth (optional) - the width of the lines in the grid
+ */
+ ROS2D.Grid = function(options) {
+    var that = this;
+    options = options || {};
+    var size = options.size || 10;
+    var cellSize = options.cellSize || 0.1;
+    var lineWidth = options.lineWidth || 0.001; 
+    // draw the arrow
+    var graphics = new createjs.Graphics();
+    // line width
+    graphics.setStrokeStyle(lineWidth*5);
+    graphics.beginStroke(createjs.Graphics.getRGB(0, 0, 0));
+    graphics.beginFill(createjs.Graphics.getRGB(255, 0, 0));
+    graphics.moveTo(-size*cellSize, 0);
+    graphics.lineTo(size*cellSize, 0);
+    graphics.moveTo(0, -size*cellSize);
+    graphics.lineTo(0, size*cellSize);
+    graphics.endFill();
+    graphics.endStroke();
+
+    graphics.setStrokeStyle(lineWidth);
+    graphics.beginStroke(createjs.Graphics.getRGB(0, 0, 0));
+    graphics.beginFill(createjs.Graphics.getRGB(255, 0, 0));
+    for (var i = -size; i <= size; i++) {
+        graphics.moveTo(-size*cellSize, i * cellSize);
+        graphics.lineTo(size*cellSize, i * cellSize);
+        graphics.moveTo(i * cellSize, -size*cellSize);
+        graphics.lineTo(i * cellSize, size*cellSize);
+    }
+    graphics.endFill();
+    graphics.endStroke();
+    // create the shape
+    createjs.Shape.call(this, graphics);
+
+};
+ROS2D.Grid.prototype.__proto__ = createjs.Shape.prototype;


### PR DESCRIPTION
This object added to OccupancyGridClient a grid map.

An example of code for run this code:
this.gridClient = new ROS2D.OccupancyGridClient({
     ros: ros,
     rootObject: viewer2D.scene
});
// Add grid to map
var gridMap = new ROS2D.Grid({
     size: 10,
     cellSize: 0.05
});
this.gridClient.rootObject.addChild(gridMap);

---

In my video, I show this grid in action on tablet, and PC.
https://www.youtube.com/watch?v=fhCHS7ibFrw

I have not tried this object with a /map received from ROS

![ipadview](https://cloud.githubusercontent.com/assets/4551246/2870124/d3f249ca-d2ae-11e3-851f-fa0d8acbddef.png)
